### PR TITLE
Solve issue where beta=2.0 didn't work due to floating type mismatch

### DIFF
--- a/torchnmf/nmf.py
+++ b/torchnmf/nmf.py
@@ -29,8 +29,8 @@ class _NMF(Base):
     def __init__(self, W_size, H_size, rank):
         super().__init__()
         self.rank = rank
-        self.W = Parameter(torch.rand(*W_size))
-        self.H = Parameter(torch.rand(*H_size))
+        self.W = Parameter(torch.rand(*W_size).double())
+        self.H = Parameter(torch.rand(*H_size).double())
 
     def forward(self, H=None, W=None):
         if H is None:


### PR DESCRIPTION
Reproduce the error using:
```python
net = NMF(cube.shape, rank=7).cuda()
_, V = net.fit_transform(cube, H=H, update_H=False, beta=2.0, verbose=1, tol=1e-12, max_iter=2000, alpha=0.0, l1_ratio=0.0)
```
where `cube` and `H` are both torch.float64 types. Whenever beta is `2.0`, a floating type mismatch occurs at the `loss.backward()` part of the optimization.

This PR solves that issue.