### PR TITLE
Provide support for arbitrary devices and dtypes

### DIFF
--- a/torchnmf/nmf.py
+++ b/torchnmf/nmf.py
@@ -207,7 +207,9 @@ class BaseComponent(torch.nn.Module):
                  W: Union[Iterable[int], Tensor] = None,
                  H: Union[Iterable[int], Tensor] = None,
                  trainable_W: bool = True,
-                 trainable_H: bool = True):
+                 trainable_H: bool = True,
+                 device: Union[str, torch.device] = 'cpu',
+                 dtype: torch.dtype = torch.float64):
         super().__init__()
 
         infer_rank = None
@@ -218,7 +220,7 @@ class BaseComponent(torch.nn.Module):
             self.W.data.copy_(W)
             infer_rank = self.W.shape[1]
         elif isinstance(W, Iterabc):
-            self.register_parameter('W', Parameter(torch.randn(*W).abs()))
+            self.register_parameter('W', Parameter(torch.randn(*W).to(device).to(dtype).abs()))
             infer_rank = W[1]
         else:
             self.register_parameter('W', None)
@@ -231,7 +233,7 @@ class BaseComponent(torch.nn.Module):
             self.H.data.copy_(H)
             infer_rank = self.H.shape[1]
         elif isinstance(H, Iterabc):
-            self.register_parameter('H', Parameter(torch.randn(*H).abs()))
+            self.register_parameter('H', Parameter(torch.randn(*H).to(device).to(dtype).abs()))
             infer_rank = H[1]
         else:
             self.register_parameter('H', None)


### PR DESCRIPTION
Simple changes to BaseComponent to support arbitrary PyTorch devices, including CUDA and Apple Silicon Metal Performance Shaders in PyTorch >= 1.12.

For Apple Silicon, MPS only support operations for torch.float32

Tested on 2021 M1 Max Macbook Pro.

Example:
```
import torch  
from torchnmf.nmf import NMF  
model = NMF((100, 100), rank=10, device='mps', dtype=torch.float32)  
model.fit(torch.randn(100, 100, dtype=torch.float32).to('mps').abs())  
print(model.W, model.H)
```